### PR TITLE
Add aws-session-manager-plugin formula and manual dep

### DIFF
--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -5,20 +5,19 @@ class AwsSessionManagerPlugin < Formula
 
   if OS.mac?
     url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/sessionmanager-bundle.zip"
+    sha256 "d9b558193370b2ecc0ddba001b6ee974b14b60d4d247851706e26a9811f15349"
 
     def install
       bin.install "bin/session-manager-plugin"
       prefix.install %w[LICENSE VERSION]
     end
 
-  sha256 "d9b558193370b2ecc0ddba001b6ee974b14b60d4d247851706e26a9811f15349"
-
   # Linux Install extracts the deb file
   elsif OS.linux?
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb"
-        sum256 "342602b05552268966bcac2ec7698447e1202eb8e3d2943066dd9954697604ef"
+        sha256 "342602b05552268966bcac2ec7698447e1202eb8e3d2943066dd9954697604ef"
       elsif Hardware::CPU.is_32_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_32bit/session-manager-plugin.deb"
       end

--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -25,7 +25,9 @@ class AwsSessionManagerPlugin < Formula
         system "tar", "xf", "data.tar.gz"
         bin.install "usr/local/sessionmanagerplugin/bin/session-manager-plugin"
         prefix.install %w[LICENSE VERSION]
+      end
     end
+  end
 
   depends_on "awscli"
 

--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -12,10 +12,13 @@ class AwsSessionManagerPlugin < Formula
     end
 
   sha256 "d9b558193370b2ecc0ddba001b6ee974b14b60d4d247851706e26a9811f15349"
+
+  # Linux Install extracts the deb file
   elsif OS.linux?
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb"
+        sum256 "342602b05552268966bcac2ec7698447e1202eb8e3d2943066dd9954697604ef"
       elsif Hardware::CPU.is_32_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_32bit/session-manager-plugin.deb"
       end
@@ -24,7 +27,7 @@ class AwsSessionManagerPlugin < Formula
         system "ar", "x", "session-manager-plugin.deb"
         system "tar", "xf", "data.tar.gz"
         bin.install "usr/local/sessionmanagerplugin/bin/session-manager-plugin"
-        prefix.install %w[LICENSE VERSION]
+        prefix.install_metafiles
       end
     end
   end

--- a/Formula/ssm-helpers.rb
+++ b/Formula/ssm-helpers.rb
@@ -14,8 +14,9 @@ class SsmHelpers < Formula
       sha256 "09d43fdc36bee747232b22a9db8601f82b8275a33bc33ca55cc7c16c4338934d"
     end
   end
-  
+
   depends_on "awscli"
+  depends_on "disneystreaming/aws-session-manager-plugin"
 
   def install
     bin.install "ssm-run"


### PR DESCRIPTION
This will allow brew to install aws-session-manager-plugin via brew with ssm-helpers.

Works on Mac and Linux (64 and 32 bit).

The manual dependency in the ssm-helpers formula will be overwritten with the next release but I'll send a different PR to address that.