### PR TITLE
update session-manager-plugin to 1.2.331.0

### DIFF
--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -1,11 +1,11 @@
 class AwsSessionManagerPlugin < Formula
   desc "Official Amazon AWS session manager plugin"
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  version "1.2.30.0"
+  version "1.2.331.0"
 
   if OS.mac?
     url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/sessionmanager-bundle.zip"
-    sha256 "900d2c3b1044edf70cb024288d581b2cccf5cd4d5ed3061e529b549b67b0bc05"
+    sha256 "eeabb8ddfc014ff52191b8b82613535a7cc2f17cfbb259fdb47dcb645b76263f"
 
     def install
       bin.install "bin/session-manager-plugin"
@@ -17,14 +17,14 @@ class AwsSessionManagerPlugin < Formula
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb"
-        sha256 "27f01987ed2977480c1ff322e0889270a3b8df43097f71e2667827e745e8bbba"
+        sha256 "c569d8f3d76c9641a145387d96544592e52a6088c740db7e4cb9e43d0af7bb54"
       elsif Hardware::CPU.is_32_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_32bit/session-manager-plugin.deb"
-        sha256 "428e1f8b1114f7dcd2b33028dd2484b0089d1746463a3fec65c1ffebd1120d9e"
+        sha256 "784a3f023be177ec90de50abe13bb42968562fae9dfd93b9994ac4e51307f685"
       end
     elsif Hardware::CPU.arm?
       url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_arm64/session-manager-plugin.deb"
-      sha256 "dddd35f810d6d4461d032f1ade48ab95dc10c06b7e5d15c533800d0a26293ec4"
+      sha256 "404ebe1232e8c9d4cfb8b8ad1ba7c02d702dbc891fca816e5a28fc6761d3ebe4"
     end
 
       def install


### PR DESCRIPTION
This PR updates the session manager plugin builds to 1.2.331.0 to take advantage of some additional port forwarding features.