### PR TITLE
Add support for signed builds for M1 from upstream

### DIFF
--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -1,11 +1,16 @@
 class AwsSessionManagerPlugin < Formula
   desc "Official Amazon AWS session manager plugin"
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  version "1.2.398.0"
+  version "1.2.463.0"
 
   if OS.mac?
-    url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/sessionmanager-bundle.zip"
-    sha256 "417f2c11f3273ef26541aea379c26b3db2a17093808a036b3d316540d1d75a88"
+    if Hardware::CPU.arm?
+      url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac_arm64/sessionmanager-bundle.zip"
+      sha256 "7daa4582b05ed2c5d8d15fd1a941b88613b06f66d1266226110649859a90809f"
+    else
+      url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/sessionmanager-bundle.zip"
+      sha256 "495a21233fa3fe2c9b929fd95283a347f272995073241b5191c7d894368fe96b"
+    end
 
     def install
       bin.install "bin/session-manager-plugin"
@@ -17,14 +22,14 @@ class AwsSessionManagerPlugin < Formula
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb"
-        sha256 "aae58e58fcfbba465231086766d236ce8d032ae73b9335690e1faba704af2f9a"
+        sha256 "cc58fc31e2239230336b243fa97bd63a7202068dd7ce8470eaf654c1928c10a8"
       elsif Hardware::CPU.is_32_bit?
         url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_32bit/session-manager-plugin.deb"
-        sha256 "5c65a842d5114c91ddca47a35a6b5da13b72732c625cfb99997a76e11eaf5e86"
+        sha256 "d23e876a7837e23e3f8b8ce64bfcaa136520109ff99adda7e1d902c2436bc719"
       end
     elsif Hardware::CPU.arm?
       url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_arm64/session-manager-plugin.deb"
-      sha256 "5c65a842d5114c91ddca47a35a6b5da13b72732c625cfb99997a76e11eaf5e86"
+      sha256 "cec94af11c44b94a43ce4ae1c2269bc257a4ed293238dd67b92c5f51827edcce"
     end
 
       def install


### PR DESCRIPTION
This PR pulls in the signed session-manager-plugin builds for the Apple M1 upstream that were released with the 1.2.463.0 release of session-manager-plugin.

This should be a prerequisite to finishing support for https://github.com/disneystreaming/ssm-helpers/issues/63